### PR TITLE
fix permission errors by running fpm master node as root

### DIFF
--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -157,8 +157,6 @@ RUN set -eux; \
 
 STOPSIGNAL SIGQUIT
 
-ENTRYPOINT ["docker-entrypoint"]
+ENTRYPOINT ["docker-entrypoint", "php-fpm"]
 WORKDIR /var/www/html
-USER www-data
 EXPOSE 9000
-CMD ["php-fpm"]

--- a/php-fpm/magento1/Dockerfile
+++ b/php-fpm/magento1/Dockerfile
@@ -10,5 +10,3 @@ RUN chmod +rx /usr/local/bin/n98-magerun \
 
 ADD https://raw.githubusercontent.com/netz98/n98-magerun/master/res/autocompletion/bash/n98-magerun.phar.bash /etc/bash_completion.d/n98-magerun.phar
 RUN chmod +r /etc/bash_completion.d/n98-magerun.phar
-
-USER www-data

--- a/php-fpm/magento1/xdebug3/Dockerfile
+++ b/php-fpm/magento1/xdebug3/Dockerfile
@@ -8,5 +8,3 @@ RUN install-php-extensions ${XDEBUG_TYPE}
 
 COPY xdebug3/etc/*.ini ${PHP_INI_DIR}/
 COPY xdebug3/etc/conf.d/* ${PHP_INI_DIR}/conf.d/
-
-USER www-data

--- a/php-fpm/magento2/Dockerfile
+++ b/php-fpm/magento2/Dockerfile
@@ -35,5 +35,3 @@ RUN mkdir /home/www-data/mage-cache-clean \
     && ln -s /home/www-data/mage-cache-clean/vendor/bin/cache-clean.js /usr/local/bin/cache-clean.js \
     && ln -s /home/www-data/mage-cache-clean/vendor/bin/cache-clean.js /usr/local/bin/cache-clean \
     && chmod +rx -R /home/www-data/mage-cache-clean
-
-USER www-data

--- a/php-fpm/magento2/xdebug3/Dockerfile
+++ b/php-fpm/magento2/xdebug3/Dockerfile
@@ -8,5 +8,3 @@ RUN install-php-extensions ${XDEBUG_TYPE}
 
 COPY xdebug3/etc/*.ini ${PHP_INI_DIR}/
 COPY xdebug3/etc/conf.d/* ${PHP_INI_DIR}/conf.d/
-
-USER www-data

--- a/php-fpm/node/Dockerfile
+++ b/php-fpm/node/Dockerfile
@@ -29,5 +29,3 @@ RUN ln -s /usr/local/bin/node /usr/local/bin/nodejs \
 
 # Copy Yarn
 COPY --from=node /opt /opt
-
-USER www-data

--- a/php-fpm/wordpress/Dockerfile
+++ b/php-fpm/wordpress/Dockerfile
@@ -9,5 +9,3 @@ ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /u
 # Create wp alias for wp-cli
 RUN chmod +rx /usr/local/bin/wp-cli \
     && ln -s /usr/local/bin/wp-cli /usr/local/bin/wp
-
-USER www-data

--- a/php-fpm/wordpress/xdebug3/Dockerfile
+++ b/php-fpm/wordpress/xdebug3/Dockerfile
@@ -8,5 +8,3 @@ RUN install-php-extensions ${XDEBUG_TYPE}
 
 COPY xdebug3/etc/*.ini ${PHP_INI_DIR}/
 COPY xdebug3/etc/conf.d/* ${PHP_INI_DIR}/conf.d/
-
-USER www-data

--- a/php-fpm/xdebug3/Dockerfile
+++ b/php-fpm/xdebug3/Dockerfile
@@ -9,5 +9,3 @@ RUN export PHP_INI_DIR="/usr/local/etc/php"; install-php-extensions ${XDEBUG_TYP
 
 COPY xdebug3/etc/*.ini /usr/local/etc/php/
 COPY xdebug3/etc/conf.d/* /usr/local/etc/php/conf.d/
-
-USER www-data


### PR DESCRIPTION
Running fpm master process as root user to prevent permission error while direct mounting on linux. 
Note: This is just temporary for now until this is properly fixed.