### PR TITLE
Fix sed in-place operations in startpage entrypoint

### DIFF
--- a/startpage/docker-entrypoint
+++ b/startpage/docker-entrypoint
@@ -19,13 +19,13 @@ echo "[INFO] Latest release: $LATEST_RELEASE"
 
 if [[ "$ROLL_VERSION" != "$LATEST_RELEASE" ]]; then
   echo "[INFO] Version mismatch detected. Updating version info in index.html..."
-  sed -ie "s/class\=\"update hide\"/class\=\"update\"/g" /usr/share/nginx/html/index.html
-  sed -ie "s/{{LATEST_RELEASE}}/${LATEST_RELEASE}/g" /usr/share/nginx/html/index.html
+  sed -i -e "s/class\=\"update hide\"/class\=\"update\"/g" /usr/share/nginx/html/index.html
+  sed -i -e "s/{{LATEST_RELEASE}}/${LATEST_RELEASE}/g" /usr/share/nginx/html/index.html
 fi
 
 echo "[INFO] Injecting ROLL_VERSION and ROLL_SERVICE_DOMAIN..."
-sed -ie "s/{{ROLL_VERSION}}/${ROLL_VERSION}/g" /usr/share/nginx/html/index.html
-sed -ie "s/{{ROLL_SERVICE_DOMAIN}}/${ROLL_SERVICE_DOMAIN}/g" /usr/share/nginx/html/index.html
+  sed -i -e "s/{{ROLL_VERSION}}/${ROLL_VERSION}/g" /usr/share/nginx/html/index.html
+  sed -i -e "s/{{ROLL_SERVICE_DOMAIN}}/${ROLL_SERVICE_DOMAIN}/g" /usr/share/nginx/html/index.html
 
 echo "[INFO] Starting fcgiwrap..."
 spawn-fcgi -s /var/run/fcgiwrap.socket -M 766 /usr/bin/fcgiwrap


### PR DESCRIPTION
## Summary
- avoid unwanted sed backup files by using `-i -e`

## Testing
- `bash -n docker-entrypoint`
- `bash -n cgi-bin/roll-status.sh`


------
https://chatgpt.com/codex/tasks/task_e_68416860b1a0832c86f99b362a5000cf