### PR TITLE
Update comment in php-fpm entrypoint

### DIFF
--- a/php-fpm/context/docker-entrypoint
+++ b/php-fpm/context/docker-entrypoint
@@ -72,7 +72,7 @@ for DIR in ${CHOWN_DIR_LIST:-}; do
   fi
 done
 
-# Add additional specified php extensions if defined on runtime
+# Add additional specified PHP extensions if defined at runtime
 if [[ "$ADD_PHP_EXT" != "" ]]; then
   /usr/local/bin/install-php-extensions "$ADD_PHP_EXT"
 fi


### PR DESCRIPTION
## Summary
- fix the wording of the comment describing additional PHP extensions in `docker-entrypoint`

## Testing
- `bash -n docker-entrypoint`

------
https://chatgpt.com/codex/tasks/task_e_68416ab5ab8c832c9e4a1e80883b63ea