### PR TITLE
Fix sed usage to avoid backup files

### DIFF
--- a/startpage/docker-entrypoint
+++ b/startpage/docker-entrypoint
@@ -19,13 +19,13 @@ echo "[INFO] Latest release: $LATEST_RELEASE"
 
 if [[ "$ROLL_VERSION" != "$LATEST_RELEASE" ]]; then
   echo "[INFO] Version mismatch detected. Updating version info in index.html..."
-  sed -ie "s/class\=\"update hide\"/class\=\"update\"/g" /usr/share/nginx/html/index.html
-  sed -ie "s/{{LATEST_RELEASE}}/${LATEST_RELEASE}/g" /usr/share/nginx/html/index.html
+  sed -i "s/class\=\"update hide\"/class\=\"update\"/g" /usr/share/nginx/html/index.html
+  sed -i "s/{{LATEST_RELEASE}}/${LATEST_RELEASE}/g" /usr/share/nginx/html/index.html
 fi
 
 echo "[INFO] Injecting ROLL_VERSION and ROLL_SERVICE_DOMAIN..."
-sed -ie "s/{{ROLL_VERSION}}/${ROLL_VERSION}/g" /usr/share/nginx/html/index.html
-sed -ie "s/{{ROLL_SERVICE_DOMAIN}}/${ROLL_SERVICE_DOMAIN}/g" /usr/share/nginx/html/index.html
+sed -i "s/{{ROLL_VERSION}}/${ROLL_VERSION}/g" /usr/share/nginx/html/index.html
+sed -i "s/{{ROLL_SERVICE_DOMAIN}}/${ROLL_SERVICE_DOMAIN}/g" /usr/share/nginx/html/index.html
 
 echo "[INFO] Starting fcgiwrap..."
 spawn-fcgi -s /var/run/fcgiwrap.socket -M 766 /usr/bin/fcgiwrap


### PR DESCRIPTION
## Summary
- update sed commands in `startpage/docker-entrypoint` to remove backup suffix

## Testing
- `bash -n startpage/docker-entrypoint`

------
https://chatgpt.com/codex/tasks/task_e_68416ab642c4832cab3187499616950b